### PR TITLE
Escape special Characters in Artifactory password

### DIFF
--- a/ace-tekton-pipelines/README.md
+++ b/ace-tekton-pipelines/README.md
@@ -186,3 +186,5 @@ oc apply -f gse-devops/ace-tekton-pipelines/cp4mcm-yamls/Application.yaml
 
 ### Trigger pipeline
 To test the pipeline, create a pull request and merge it into the git repository forked from [ACE Toolkit workspace](https://github.com/ibm-cloud-architecture/devops-demo-sample-ace-project).  Once the pull request has been merged, a PipelineRun execution should start and can be viewed from the OpenShift Console in the `Pipelines` > `PipelineRuns` menu.
+
+Test 1

--- a/ace-tekton-pipelines/README.md
+++ b/ace-tekton-pipelines/README.md
@@ -186,5 +186,3 @@ oc apply -f gse-devops/ace-tekton-pipelines/cp4mcm-yamls/Application.yaml
 
 ### Trigger pipeline
 To test the pipeline, create a pull request and merge it into the git repository forked from [ACE Toolkit workspace](https://github.com/ibm-cloud-architecture/devops-demo-sample-ace-project).  Once the pull request has been merged, a PipelineRun execution should start and can be viewed from the OpenShift Console in the `Pipelines` > `PipelineRuns` menu.
-
-Test 1

--- a/ace-tekton-pipelines/tekton-yamls/Tasks/cp4i-ace-build-bar-task.yaml
+++ b/ace-tekton-pipelines/tekton-yamls/Tasks/cp4i-ace-build-bar-task.yaml
@@ -65,8 +65,6 @@ spec:
     envFrom:
     - secretRef:
         name: artifactory-credentials
-    - secretRef:
-        name: ibm-cr-pull-secret
 
     image: $(params.BUILDER_IMAGE)
     name: build-image
@@ -80,8 +78,6 @@ spec:
     - '-c'
     - >
       set -e
-
-      buildah ls
 
       buildah push --tls-verify=$(params.TLSVERIFY)
       "$(params.imageUrl):$(params.imageTag)"

--- a/ace-tekton-pipelines/tekton-yamls/Tasks/cp4i-ace-build-bar-task.yaml
+++ b/ace-tekton-pipelines/tekton-yamls/Tasks/cp4i-ace-build-bar-task.yaml
@@ -43,7 +43,7 @@ spec:
     - |
       set -eu;
       #source ./env-config
-      curl -u $(ARTIFACTORY_USER):$(ARTIFACTORY_PASSWORD) -O "$(ARTIFACTORY_URL)/artifactory/$(params.artifactoryRepo)/$(params.project)-$(params.imageTag).bar"
+      curl -u ${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD} -O "$(ARTIFACTORY_URL)/artifactory/$(params.artifactoryRepo)/$(params.project)-$(params.imageTag).bar"
 
       pwd
       ls -la
@@ -58,12 +58,16 @@ spec:
       #ls -la
 
       printf "Building image\n"
+      
       buildah bud --build-arg PROJECT1=$(params.project) --tls-verify=$(params.TLSVERIFY) --layers -f $(params.DOCKERFILE) -t $(params.imageUrl):$(params.imageTag) $(params.CONTEXT)
     command:
     - /bin/bash
     envFrom:
     - secretRef:
         name: artifactory-credentials
+    - secretRef:
+        name: ibm-cr-pull-secret
+
     image: $(params.BUILDER_IMAGE)
     name: build-image
     securityContext:
@@ -76,6 +80,8 @@ spec:
     - '-c'
     - >
       set -e
+
+      buildah ls
 
       buildah push --tls-verify=$(params.TLSVERIFY)
       "$(params.imageUrl):$(params.imageTag)"

--- a/ace-tekton-pipelines/tekton-yamls/Tasks/cp4i-ace-generate-bar-task.yaml
+++ b/ace-tekton-pipelines/tekton-yamls/Tasks/cp4i-ace-generate-bar-task.yaml
@@ -70,7 +70,7 @@ spec:
 
       echo Compile completed
       echo "Push the bar file to artifactory"
-      curl -u $(ARTIFACTORY_USER):$(ARTIFACTORY_PASSWORD) -T $(params.project)/gen/$(params.project)-$(params.imageTag).bar "$(ARTIFACTORY_URL)/artifactory/$(params.artifactoryRepo)/$(params.project)-$(params.imageTag).bar"
+      curl -u ${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD} -T $(params.project)/gen/$(params.project)-$(params.imageTag).bar "$(ARTIFACTORY_URL)/artifactory/$(params.artifactoryRepo)/$(params.project)-$(params.imageTag).bar"
     command:
     - /bin/sh
     envFrom:


### PR DESCRIPTION
If `ARTIFACTORY_PASSWORD` ends with a `-`, then bash throws `-: command not found` error. Fixed this issue by escaping special characters in password string. 